### PR TITLE
Fix width of demo page containers

### DIFF
--- a/demo/barchart_basic_demo.html
+++ b/demo/barchart_basic_demo.html
@@ -13,6 +13,9 @@
     <link rel="import" href="../barchart-basic.html">
 
     <style is="custom-style" include="demo-pages-shared-styles">
+      div.vertical-section-container {
+        max-width: 1500px;
+      }
     </style>
   </head>
   <body>

--- a/demo/piechart_basic_demo.html
+++ b/demo/piechart_basic_demo.html
@@ -13,6 +13,9 @@
     <link rel="import" href="../piechart-basic.html">
 
     <style is="custom-style" include="demo-pages-shared-styles">
+      div.vertical-section-container {
+        max-width: 1500px;
+      }
     </style>
   </head>
   <body>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Modern Extensible, and Interactive Number Exploration Library
+# Modern, Extensible and Interactive Number Exploration Library
 This is the landing page of the m.e.i.n.e.l. project and will include the documentation of the project in the future.
 
 ## Cloning


### PR DESCRIPTION
Fixed the width of the demo containers from having
a max-width of 400px to 1500px to support larger
displays and especially graphs.

Also fixed a typo in the docs.