### PR TITLE
remove hidden display of data formerly used due to undefinded data

### DIFF
--- a/src/barchart-basic.html
+++ b/src/barchart-basic.html
@@ -16,7 +16,6 @@ This is a basic component for plotly barcharts
         display: block;
       }
     </style>
-    <div style="display:none;">{{data}}</div>
     <div id="diagram"></div>
   </template>
 

--- a/src/data-filter.html
+++ b/src/data-filter.html
@@ -30,7 +30,6 @@ This is a component for filtering data based on user input.
         on-response="handleResponse"
         debounce-duration="300">
     </iron-ajax>
-    <div style="display:none;">{{data}}</div>
     <div id="filterBar"></div>
     <linechart-basic id="linechart" data={{data}} width={{width}} height={{height}}></linechart-basic>
   </template>

--- a/src/linechart-basic.html
+++ b/src/linechart-basic.html
@@ -16,7 +16,6 @@ This is a basic component for plotly linecharts
         display: block;
       }
     </style>
-    <div style="display:none;">{{data}}</div>
     <div id="diagram"></div>
   </template>
     <script>


### PR DESCRIPTION
Removed the hidden div we needed formerly to suppress undefinded-values warning.
Seems like since we're using attached instead of ready the attributes are properly initialized when we start using them.
Please pull this branch and test it before merging. I didn't had any problems, but different machines, different behavior ;)
You might also have a look at the corresponding issue #26 